### PR TITLE
Add sim primary vertex z variable

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/gen/GeneratorAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/gen/GeneratorAnalyzer.py
@@ -193,6 +193,8 @@ class GeneratorAnalyzer( Analyzer ):
             event.genbquarksFromTop = []
             event.genbquarksFromH   = []
             event.genlepsFromTop = []
+            event.genvertex = 0
+            if len(event.generatorSummary)>2: event.genvertex=event.generatorSummary[2].vertex().z()
             for p in event.generatorSummary:
                 id = abs(p.pdgId())
                 if id == 25: 

--- a/VHbbAnalysis/Heppy/test/vhbb.py
+++ b/VHbbAnalysis/Heppy/test/vhbb.py
@@ -57,6 +57,7 @@ treeProducer= cfg.Analyzer(
 		 NTupleVariable("tkMet_pt",  lambda ev : ev.tkMet.pt(), help="E_{T}^{miss} from tracks"),
 		 NTupleVariable("tkMetPVchs_pt",  lambda ev : ev.tkMetPVchs.pt(), help="E_{T}^{miss} from tracks"),
 		 NTupleVariable("isrJetVH",  lambda ev : ev.isrJetVH, help="Index of ISR jet in VH"),
+		 NTupleVariable("simPrimaryVertex_z", lambda ev: ev.genvertex, float,mcOnly=True, help="z coordinate of the simulated primary vertex"),
 	],
 	globalObjects = {
           "met"    : NTupleObject("met",     metType, help="PF E_{T}^{miss}, after default type 1 corrections"),


### PR DESCRIPTION
This PR add the variable "simPrimaryVertex_z" to the tree.
The variable is the 'z' coordinate of the vertex of the third gen particles.
It corresponds to the position of the simulated primary vertex.