### PR TITLE
Add data dataset and dcsonly json to vhbb_data 

### DIFF
--- a/VHbbAnalysis/Heppy/test/crab/datasets_DATA_25ns.txt
+++ b/VHbbAnalysis/Heppy/test/crab/datasets_DATA_25ns.txt
@@ -1,0 +1,8 @@
+/DoubleEG/Run2015C-PromptReco-v1/MINIAOD
+/DoubleMuon/Run2015C-PromptReco-v1/MINIAOD
+/HTMHT/Run2015C-PromptReco-v1/MINIAOD
+/JetHT/Run2015C-PromptReco-v1/MINIAOD
+/MET/Run2015C-PromptReco-v1/MINIAOD
+/MuonEG/Run2015C-PromptReco-v1/MINIAOD
+/SingleElectron/Run2015C-PromptReco-v1/MINIAOD
+/SingleMuon/Run2015C-PromptReco-v1/MINIAOD

--- a/VHbbAnalysis/Heppy/test/crab/datasets_DATA_25ns.txt
+++ b/VHbbAnalysis/Heppy/test/crab/datasets_DATA_25ns.txt
@@ -2,6 +2,7 @@
 /DoubleMuon/Run2015C-PromptReco-v1/MINIAOD
 /HTMHT/Run2015C-PromptReco-v1/MINIAOD
 /JetHT/Run2015C-PromptReco-v1/MINIAOD
+/Jet/Run2015C-PromptReco-v1/MINIAOD
 /MET/Run2015C-PromptReco-v1/MINIAOD
 /MuonEG/Run2015C-PromptReco-v1/MINIAOD
 /SingleElectron/Run2015C-PromptReco-v1/MINIAOD

--- a/VHbbAnalysis/Heppy/test/crab/datasets_DATA_50ns.txt
+++ b/VHbbAnalysis/Heppy/test/crab/datasets_DATA_50ns.txt
@@ -7,4 +7,3 @@
 /DoubleEG/Run2015B-PromptReco-v1/MINIAOD
 /DoubleMuon/Run2015B-PromptReco-v1/MINIAOD
 /MuonEG/Run2015B-PromptReco-v1/MINIAOD
-

--- a/VHbbAnalysis/Heppy/test/crab/datasets_DATA_50ns.txt
+++ b/VHbbAnalysis/Heppy/test/crab/datasets_DATA_50ns.txt
@@ -1,0 +1,10 @@
+/HTMHT/Run2015B-PromptReco-v1/MINIAOD
+/Jet/Run2015B-PromptReco-v1/MINIAOD
+/JetHT/Run2015B-PromptReco-v1/MINIAOD
+/MET/Run2015B-PromptReco-v1/MINIAOD
+/SingleElectron/Run2015B-PromptReco-v1/MINIAOD
+/SingleMuon/Run2015B-PromptReco-v1/MINIAOD
+/DoubleEG/Run2015B-PromptReco-v1/MINIAOD
+/DoubleMuon/Run2015B-PromptReco-v1/MINIAOD
+/MuonEG/Run2015B-PromptReco-v1/MINIAOD
+

--- a/VHbbAnalysis/Heppy/test/vhbb_data.py
+++ b/VHbbAnalysis/Heppy/test/vhbb_data.py
@@ -5,6 +5,9 @@ sample.isData=True
 sample.files=[
  "root://xrootd.unl.edu//store/data/Run2015B/SingleMuon/MINIAOD/PromptReco-v1/000/251/162/00000/160C08A3-4227-E511-B829-02163E01259F.root"
 ]
+sample.json="/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/DCSOnly/json_DCSONLY.txt" #from https://twiki.cern.ch/twiki/bin/viewauth/CMS/PdmV2015Analysis
+
+
 FlagsAna.processName='RECO'
 TrigAna.triggerBits = triggerTableData
 


### PR DESCRIPTION
Data dataset separated for run201B (50 ns) and run2015C (25 ns, except one run 254833 at 50 ns not certified so far, information taken from https://twiki.cern.ch/twiki/bin/viewauth/CMS/PdmV2015Analysis)