### PR TITLE
Add hadronic triggers for X->HH->4b

### DIFF
--- a/VHbbAnalysis/Heppy/python/TriggerTable.py
+++ b/VHbbAnalysis/Heppy/python/TriggerTable.py
@@ -52,6 +52,7 @@ triggerTable = {
     "WenHbbAll" : [
         "HLT_Ele32_eta2p1_WP75_Gsf_v*",
         "HLT_Ele32_eta2p1_WP75_Gsf_CentralPFJet30_BTagCSV07_v*",
+        "HLT_Ele22_eta2p1_WP75_Gsf_v*",
         "HLT_Ele27_eta2p1_WP85_Gsf_HT200_v*",
         "HLT_Ele27_WP85_Gsf_v*",
         "HLT_Ele27_eta2p1_WP75_Gsf_v*",

--- a/VHbbAnalysis/Heppy/python/TriggerTable.py
+++ b/VHbbAnalysis/Heppy/python/TriggerTable.py
@@ -1,3 +1,6 @@
+## Trigger menu in MC: /dev/CMSSW_7_4_0/GRun/V41 (default in CMSSW_7_4_1)
+## http://cmslxr.fnal.gov/source/HLTrigger/Configuration/python/HLT_GRun_cff.py?v=CMSSW_7_4_1
+
 triggerTable = {
     "ZnnHbbAll" : [
         "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDLoose_BTagCSV0p7_v*",
@@ -221,5 +224,8 @@ triggerTable = {
         "HLT_PFJet320_v*",
         "HLT_PFJet400_v*",
         "HLT_PFJet450_v*",
+        "HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV0p41_v*",
+        "HLT_AK8PFHT700_TrimR0p1PT0p03Mass50_v*",
+        "HLT_AK8PFJet360_TrimMass30_v*",
     ],
 }

--- a/VHbbAnalysis/Heppy/python/TriggerTableData.py
+++ b/VHbbAnalysis/Heppy/python/TriggerTableData.py
@@ -1,3 +1,5 @@
+## Trigger used on data available on: http://cmslxr.fnal.gov/source/HLTrigger/Configuration/python/HLT_GRun_cff.py?v=CMSSW_7_5_4
+
 triggerTable = {
     "ZnnHbbAll" : [
         "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDTight_BTagCSV0p72_v*",
@@ -249,5 +251,12 @@ triggerTable = {
         "HLT_DiPFJetAve200_v*",
         "HLT_DiPFJetAve260_v*",
         "HLT_DiPFJetAve320_v*",
+
+        "HLT_AK8DiPFJet250_200_TrimMass30_BTagCSV0p45_v*",
+        "HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV0p45_v*",
+        "HLT_AK8PFHT600_TrimR0p1PT0p03Mass50_BTagCSV0p45_v*",
+        "HLT_AK8PFHT650_TrimR0p1PT0p03Mass50_v*",
+        "HLT_AK8PFHT700_TrimR0p1PT0p03Mass50_v*",
+        "HLT_AK8PFJet360_TrimMass30_v*",
     ],
 }


### PR DESCRIPTION
This PR add the following triggers.
In the MC:
HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV0p41_v1',
HLT_AK8PFHT700_TrimR0p1PT0p03Mass50_v1',
HLT_AK8PFJet360_TrimMass30_v1',

HLT_Ele22_eta2p1_WP75_Gsf_v

In data:
HLT_AK8DiPFJet250_200_TrimMass30_BTagCSV0p45_v2
HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV0p45_v3
HLT_AK8PFHT600_TrimR0p1PT0p03Mass50_BTagCSV0p45_v2
HLT_AK8PFHT650_TrimR0p1PT0p03Mass50_v2
HLT_AK8PFHT700_TrimR0p1PT0p03Mass50_v3
HLT_AK8PFJet360_TrimMass30_v3 

Silvio.
