### PR TITLE
gen top decay mode finding

### DIFF
--- a/VHbbAnalysis/Heppy/python/VHGeneratorAnalyzer.py
+++ b/VHbbAnalysis/Heppy/python/VHGeneratorAnalyzer.py
@@ -111,9 +111,33 @@ class GeneratorAnalyzer( Analyzer ):
         """Get the b quarks from top decays into event.genbquarksFromTop"""
 
         event.gentopquarks = [ p for p in event.genParticles if abs(p.pdgId()) == 6 and p.numberOfDaughters() > 0 and abs(p.daughter(0).pdgId()) != 6 ]
-        #if len(event.gentopquarks) != 2:
-        #    print "Not two top quarks? \n%s\n" % event.gentopquarks
-
+       
+        #Find the top decay mode (0 - leptonic, 1 - hadronic)
+        for top in event.gentopquarks:
+            ndaus = top.numberOfDaughters()
+            top.decayMode = -1
+            
+            #go over top daughters
+            for idau in range(ndaus):
+                dau = top.daughter(idau)
+                #found the W
+                if abs(dau.pdgId()) == 24:
+                    #find the true daughters of the W (in case of decay chain)
+                    W_daus = realGenDaughters(dau)
+                    decayMode = -1
+                    #go over the daughters of the W
+                    for idauw in range(len(W_daus)):
+                        w_dau_id = abs(W_daus[idauw].pdgId())
+                        #leptonic
+                        if w_dau_id in [11,12,13,14,15,16]:
+                            decayMode = 0
+                            break
+                        #hadronic
+                        elif w_dau_id < 6:
+                            decayMode = 1
+                            break
+                    top.decayMode = decayMode
+                    break
         for tq in event.gentopquarks:
             for i in xrange( tq.numberOfDaughters() ):
                 dau = GenParticle(tq.daughter(i))

--- a/VHbbAnalysis/Heppy/python/vhbbobj.py
+++ b/VHbbAnalysis/Heppy/python/vhbbobj.py
@@ -344,6 +344,10 @@ genTauJetType = NTupleObjectType("genTauJet", baseObjectTypes = [ genParticleTyp
     NTupleVariable("decayMode", lambda x : x.decayMode, int, mcOnly=True, help="Generator level tau decay mode"),
 ])
 
+genTopType = NTupleObjectType("genTopType", baseObjectTypes = [ genParticleType ], variables = [
+    NTupleVariable("decayMode", lambda x : x.decayMode, int, mcOnly=True, help="Generator level top decay mode: 0=leptonic, 1=hadronic, -1=not known"),
+])
+
 genJetType = NTupleObjectType("genJet", baseObjectTypes = [ genParticleType ], variables = [
     NTupleVariable("numBHadrons", lambda x : getattr(x,"numBHadronsBeforeTop",-1), int, mcOnly=True, help="number of matched b hadrons before top quark decay"),
     NTupleVariable("numCHadrons", lambda x : getattr(x,"numCHadronsBeforeTop",-1), int, mcOnly=True, help="number of matched c hadrons before top quark decay"),

--- a/VHbbAnalysis/Heppy/test/vhbb.py
+++ b/VHbbAnalysis/Heppy/test/vhbb.py
@@ -112,7 +112,7 @@ treeProducer= cfg.Analyzer(
                 #"generatorSummary"    : NTupleCollection("GenSummary", genParticleWithLinksType, 30, help="Generator summary, see description in Heppy GeneratorAnalyzer",mcOnly=True),
                 "genJets"    : NTupleCollection("GenJet",   genJetType, 15, help="Generated jets with hadron matching, sorted by pt descending",filter=lambda x: x.pt() > 20,mcOnly=True),
                 "genHiggsSisters"    : NTupleCollection("GenHiggsSisters",     genParticleType, 4, help="Sisters of the Higgs bosons"),
-                "gentopquarks"    : NTupleCollection("GenTop",     genParticleType, 4, help="Generated top quarks from hard scattering"),
+                "gentopquarks"    : NTupleCollection("GenTop",     genTopType, 4, help="Generated top quarks from hard scattering"),
                 "genallstatus2bhadrons"    : NTupleCollection("GenStatus2bHad",     genParticleType, 15, help="Generated Status 2 b Hadrons"),
                 "gennusFromTop"    : NTupleCollection("GenNuFromTop",     genParticleType, 4, help="Generated neutrino from t->W decay"),
                 "genbquarksFromH"      : NTupleCollection("GenBQuarkFromH",  genParticleType, 4, help="Generated bottom quarks from Higgs decays"),


### PR DESCRIPTION
Saves a flag "decayMode" on gen tops, specifying the decay mode of the W. 
Needed to be able to match hadronic gen tops to boosted top candidates. 
