### PR TITLE
heppy: JET cleaning for MET, mva ID for leptons

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
@@ -125,9 +125,10 @@ class JetAnalyzer( Analyzer ):
 
         self.deltaMetFromJEC = [0.,0.]
 #        print "before. rho",self.rho,self.cfg_ana.collectionPostFix,'allJets len ',len(allJets),'pt', [j.pt() for j in allJets]
+        self.allJetsUsedForMET = filter(lambda jet: self.cfg_ana.jetsForMetCut, allJets)
+        allJets = self.allJetsUsedForMET
         if self.doJEC:
             self.jetReCalibrator.correctAll(allJets, rho, delta=self.shiftJEC, metShift=self.deltaMetFromJEC, addCorr=True, addShifts=self.addJECShifts)           
-        self.allJetsUsedForMET = allJets
 #        print "after. rho",self.rho,self.cfg_ana.collectionPostFix,'allJets len ',len(allJets),'pt', [j.pt() for j in allJets]
 
         if self.cfg_comp.isMC:
@@ -254,8 +255,8 @@ class JetAnalyzer( Analyzer ):
         #MC stuff
         if self.cfg_comp.isMC:
             self.deltaMetFromJetSmearing = [0, 0]
-            for j in self.cleanJetsAll:
-                if hasattr(j, 'deltaMetFromJetSmearing'):
+            for j in allJets:
+                if self.cfg_ana.propagateJetSmearToMET and hasattr(j, 'deltaMetFromJetSmearing'):
                     self.deltaMetFromJetSmearing[0] += j.deltaMetFromJetSmearing[0]
                     self.deltaMetFromJetSmearing[1] += j.deltaMetFromJetSmearing[1]
 
@@ -438,6 +439,8 @@ setattr(JetAnalyzer,"defaultConfig", cfg.Analyzer(
     shiftJEC = 0, # set to +1 or -1 to apply +/-1 sigma shift to the nominal jet energies
     addJECShifts = False, # if true, add  "corr", "corrJECUp", and "corrJECDown" for each jet (requires uncertainties to be available!)
     smearJets = True,
+    propagateJetSmearToMET = False,
+    jetsForMetCut = lambda jet: True, #use only these jets for JEC/JER propagation to MET
     shiftJER = 0, # set to +1 or -1 to get +/-1 sigma shifts    
     addJERShifts = 0, # add +/-1 sigma shifts to jets, intended to be used with shiftJER=0
     cleanJetsFromFirstPhoton = False,

--- a/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
@@ -90,6 +90,10 @@ class LeptonAnalyzer( Analyzer ):
         self.handles['rhoMu'] = AutoHandle( self.cfg_ana.rhoMuon, 'double')
         #rho for electrons
         self.handles['rhoEle'] = AutoHandle( self.cfg_ana.rhoElectron, 'double')
+        
+        #Electron MVA ID
+        self.handles['mvaidEleMediumId'] = AutoHandle( self.cfg_ana.mvaidElectronMediumId, 'edm::ValueMap<bool>')
+        self.handles['mvaidEle'] = AutoHandle( self.cfg_ana.mvaidElectron, 'edm::ValueMap<float>')
 
         if self.doMiniIsolation or self.doIsolationScan:
             self.handles['packedCandidates'] = AutoHandle( self.cfg_ana.packedCandidates, 'std::vector<pat::PackedCandidate>')
@@ -274,7 +278,14 @@ class LeptonAnalyzer( Analyzer ):
         """
                make a list of all electrons, and apply basic corrections to them
         """
+
+        #https://twiki.cern.ch/twiki/bin/viewauth/CMS/MultivariateElectronIdentificationRun2#Recipes_for_7_4_12_Spring15_MVA
         allelectrons = map( Electron, self.handles['electrons'].product() )
+        mvaIdMediumId = self.handles['mvaidEleMediumId'].product()
+        mvaId = self.handles['mvaidEle'].product()
+        for ie, ele in enumerate(allelectrons):
+            ele.mediumIdResult = mvaIdMediumId.get(ie)
+            ele.mvaId = mvaId.get(ie)
 
         ## Duplicate removal for fast sim (to be checked if still necessary in latest greatest 5.3.X releases)
         allelenodup = []
@@ -571,6 +582,8 @@ setattr(LeptonAnalyzer,"defaultConfig",cfg.Analyzer(
     loose_electron_relIso = 0.4,
     # loose_electron_isoCut = lambda electron : electron.miniRelIso < 0.1
     loose_electron_lostHits = 1.0,
+    mvaidElectronMediumId = "egmGsfElectronIDs:mvaEleID-Spring15-25ns-Trig-V1-wp80",
+    mvaidElectron = "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15Trig25nsV1Values",
     # muon isolation correction method (can be "rhoArea" or "deltaBeta")
     mu_isoCorr = "rhoArea" ,
     mu_effectiveAreas = "Phys14_25ns_v1", #(can be 'Data2012' or 'Phys14_25ns_v1')


### PR DESCRIPTION
Heppy side of #258.

Uses jets that have been explicitly cleaned for propagating corrections to MET.
LeptonAnalyzer now gets MVA ID from EGM valuemaps.
