### PR TITLE
use "triggerTableData" in 76X MC

### DIFF
--- a/VHbbAnalysis/Heppy/test/vhbb.py
+++ b/VHbbAnalysis/Heppy/test/vhbb.py
@@ -293,7 +293,7 @@ from VHbbAnalysis.Heppy.TriggerTableData import triggerTable as triggerTableData
 TrigAna = cfg.Analyzer(
     verbose = False,
     class_object = TriggerBitAnalyzer,
-    triggerBits = triggerTable,  #default is MC, use the triggerTableData in -data.py files
+    triggerBits = TriggerTableData,  #in 76X simulation and Run2015 data use the same HLT menu
 #   processName = 'HLT',
 #   outprefix = 'HLT'
    )


### PR DESCRIPTION
The 76X MC and Run2015 data use exactly the same HLT menu.
We just have to move from "TriggerTable" to "TriggerTableData" in the vhbb.py in order to get the proper HLT bits in the ntuples from 76X samples.