### PR TITLE
Adding hadronic triggers for HH -> 4b

### DIFF
--- a/VHbbAnalysis/Heppy/python/TriggerTableData.py
+++ b/VHbbAnalysis/Heppy/python/TriggerTableData.py
@@ -208,6 +208,13 @@ triggerTable = {
     "HH4bLowLumi" : [
         "HLT_QuadJet45_TripleBTagCSV0p67_v*",
         "HLT_DoubleJet90_Double30_TripleBTagCSV0p67_v*",
+
+        "HLT_AK8DiPFJet250_200_TrimMass30_BTagCSV0p45_v*",
+        "HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV0p45_v*",
+        "HLT_AK8PFHT600_TrimR0p1PT0p03Mass50_BTagCSV0p45_v*",
+        "HLT_AK8PFHT650_TrimR0p1PT0p03Mass50_v*",
+        "HLT_AK8PFHT700_TrimR0p1PT0p03Mass50_v*",
+        "HLT_AK8PFJet360_TrimMass30_v*",
     ],
     "ttHleptonic" : [
         "HLT_Mu17_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v*",


### PR DESCRIPTION
We have to add the following triggers that are useful for the X->HH->4b:
HLT_AK8DiPFJet250_200_TrimMass30_BTagCSV0p45_v2
HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV0p45_v3
HLT_AK8PFHT600_TrimR0p1PT0p03Mass50_BTagCSV0p45_v2
HLT_AK8PFHT650_TrimR0p1PT0p03Mass50_v2
HLT_AK8PFHT700_TrimR0p1PT0p03Mass50_v3
HLT_AK8PFJet360_TrimMass30_v3