### PR TITLE
New trigger table for 76X MC

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/core/TriggerObjectsAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/TriggerObjectsAnalyzer.py
@@ -66,7 +66,7 @@ class TriggerObjectsAnalyzer( Analyzer ):
 setattr(TriggerObjectsAnalyzer,"defaultConfig",cfg.Analyzer(
     TriggerObjectsAnalyzer, name="TriggerObjectsAnalyzerDefault",
     triggerObjectsCfgs = {"caloJets":(("hltAK4CaloJetsCorrectedIDPassed")),"caloMet":(("hltMet","","HLT"),"hltMET90","HLT_PFMET90_PFMHT90_IDTight*")},
-    triggerObjectInputTag = ('selectedPatTrigger','','PAT'),
+    triggerObjectInputTag = ('selectedPatTrigger','','RECO'),
     triggerBitsInputTag = ('TriggerResults','','HLT')
 )
 )

--- a/VHbbAnalysis/Heppy/python/TriggerTable.py
+++ b/VHbbAnalysis/Heppy/python/TriggerTable.py
@@ -1,68 +1,76 @@
+## Trigger used in 76X: http://cmslxr.fnal.gov/source/HLTrigger/Configuration/python/HLT_25ns14e33_v4_cff.py?v=CMSSW_7_6_1
 triggerTable = {
+    "ZnnHbb" : [
+        "HLT_PFMET90_PFMHT90_IDTight_v*",
+        "HLT_PFMET170_NoiseCleaned_v*",
+    ],
     "ZnnHbbAll" : [
-        "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDLoose_BTagCSV0p7_v*",
-        "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDLoose_v*",
-        "HLT_PFMET90_PFMHT90_IDLoose_v*",
-        "HLT_PFMET100_PFMHT100_IDLoose_v*",
-        "HLT_PFMET110_PFMHT110_IDLoose_v*",
-        "HLT_PFMET120_PFMHT120_IDLoose_v*",
+        "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDTight_BTagCSV0p72_v*",
+        "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDTight_v*",
+        "HLT_PFMET90_PFMHT90_IDTight_v*",
+        "HLT_PFMET100_PFMHT100_IDTight_v*",
+        "HLT_PFMET110_PFMHT110_IDTight_v*",
+        "HLT_PFMET120_PFMHT120_IDTight_v*",
         "HLT_PFMET170_NoiseCleaned_v*",
-        "HLT_DiCentralPFJet70_PFMET120_NoiseCleaned_v*",
-        "HLT_PFHT350_PFMET120_NoiseCleaned_v*",
+        "HLT_DiCentralPFJet55_PFMET110_NoiseCleaned_v*",
+        "HLT_PFHT350_PFMET100_NoiseCleaned_v*",
     ],
-    "ZnnHbbHighLumi" : [
-        "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDLoose_BTagCSV0p7_v*",
-        "HLT_PFMET120_PFMHT120_IDLoose_v*",
-        "HLT_PFMET170_NoiseCleaned_v*",
-    ],
-    "ZnnHbbLowLumi" : [
-        "HLT_PFMET90_PFMHT90_IDLoose_v*",
-    ],
-
     "ZeeHbbAll" : [
         "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*",
         "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v*",
         "HLT_Ele23_CaloIdL_TrackIdL_IsoVL_v*",
-        "HLT_DoubleEle24_22_eta2p1_WP75_Gsf_v*",
+        "HLT_DoubleEle24_22_eta2p1_WPLoose_Gsf_v*",
         "HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*",
         "HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_v*",
         "HLT_Ele12_CaloIdL_TrackIdL_IsoVL_v*",
-        "HLT_Ele32_eta2p1_WP75_Gsf_v*",
-        "HLT_Ele32_eta2p1_WP75_Gsf_CentralPFJet30_BTagCSV07_v*",
-        "HLT_Ele27_eta2p1_WP85_Gsf_HT200_v*",
-        "HLT_Ele27_WP85_Gsf_v*",
-        "HLT_Ele27_eta2p1_WP75_Gsf_v*",
-        "HLT_Ele27_eta2p1_WP75_Gsf_CentralPFJet30_BTagCSV07_v*",
+        "HLT_Ele32_eta2p1_WPLoose_Gsf_v*",
+        "HLT_Ele32_eta2p1_WPLoose_Gsf_CentralPFJet30_BTagCSV07_v*",
+        "HLT_Ele27_eta2p1_WPLoose_Gsf_HT200_v*",
+        "HLT_Ele27_eta2p1_WPLoose_Gsf_v*",
+        "HLT_Ele27_eta2p1_WPTight_Gsf_v*",
+        "HLT_Ele27_eta2p1_WPLoose_Gsf_CentralPFJet30_BTagCSV07_v*",
+        "HLT_Ele22_eta2p1_WPTight_Gsf_v*",
+        "HLT_Ele22_eta2p1_WPLoose_Gsf_v*",
+        "HLT_Ele23_WPLoose_Gsf_v*",
+        "HLT_Ele27_WPLoose_Gsf_v*",
         "HLT_Ele105_CaloIdVT_GsfTrkIdT_v*",
         "HLT_Ele45_CaloIdVT_GsfTrkIdT_PFJet200_PFJet50_v*",
+        "HLT_Ele30WP60_Ele8_Mass55_v*"
     ],
     "ZeeHbbHighLumi" : [
         "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*",
-        "HLT_DoubleEle24_22_eta2p1_WP75_Gsf_v*"
+        "HLT_DoubleEle24_22_eta2p1_WPLoose_Gsf_v*"
     ],
     "ZeeHbbLowLumi" : [
         "HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*",
-        "HLT_DoubleEle24_22_eta2p1_WP75_Gsf_v*"
+        "HLT_DoubleEle24_22_eta2p1_WPLoose_Gsf_v*"
     ],
 
 
     "WenHbbAll" : [
-        "HLT_Ele32_eta2p1_WP75_Gsf_v*",
-        "HLT_Ele32_eta2p1_WP75_Gsf_CentralPFJet30_BTagCSV07_v*",
-        "HLT_Ele27_eta2p1_WP85_Gsf_HT200_v*",
-        "HLT_Ele27_WP85_Gsf_v*",
-        "HLT_Ele27_eta2p1_WP75_Gsf_v*",
-        "HLT_Ele27_eta2p1_WP75_Gsf_CentralPFJet30_BTagCSV07_v*",
+        "HLT_Ele32_eta2p1_WPLoose_Gsf_v*",
+        "HLT_Ele32_eta2p1_WPLoose_Gsf_CentralPFJet30_BTagCSV07_v*",
+        "HLT_Ele27_eta2p1_WPLoose_Gsf_HT200_v*",
+        "HLT_Ele27_eta2p1_WPLoose_Gsf_v*",
+        "HLT_Ele27_eta2p1_WPTight_Gsf_v*",
+        "HLT_Ele27_eta2p1_WPLoose_Gsf_CentralPFJet30_BTagCSV07_v*",
         "HLT_Ele105_CaloIdVT_GsfTrkIdT_v*",
         "HLT_Ele45_CaloIdVT_GsfTrkIdT_PFJet200_PFJet50_v*",
+        "HLT_Ele27_WPLoose_Gsf_WHbbBoost_v*",
+        "HLT_Ele22_eta2p1_WPTight_Gsf_v*",
+        "HLT_Ele22_eta2p1_WPLoose_Gsf_v*",
+        "HLT_Ele23_WPLoose_Gsf_v*",
+        "HLT_Ele27_WPLoose_Gsf_v*",
+        "HLT_Ele23_WPLoose_Gsf_WHbbBoost_v*",
     ],
     "WenHbbHighLumi" : [
-        "HLT_Ele32_eta2p1_WP75_Gsf_v*",
-        "HLT_Ele27_eta2p1_WP85_Gsf_HT200_v*",
+        "HLT_Ele32_eta2p1_WPLoose_Gsf_v*",
+        "HLT_Ele27_eta2p1_WPLoose_Gsf_HT200_v*",
+        "HLT_Ele27_WPLoose_Gsf_WHbbBoost_v*",
     ],
     "WenHbbLowLumi" : [
-        "HLT_Ele27_eta2p1_WP75_Gsf_v*",
-        "HLT_Ele27_eta2p1_WP85_Gsf_HT200_v*",
+        "HLT_Ele27_eta2p1_WPTight_Gsf_v*",
+        "HLT_Ele27_eta2p1_WPLoose_Gsf_HT200_v*",
     ],
 
     "ZmmHbbAll" : [
@@ -90,6 +98,10 @@ triggerTable = {
         "HLT_Mu20_v*",
         "HLT_TkMu20_v*",
         "HLT_Mu40_eta2p1_PFJet200_PFJet50_v*",
+        "HLT_IsoMu18_v*",
+        "HLT_OldIsoMu18_v*",
+        "HLT_IsoTkMu18_v*",
+        "HLT_OldIsoTkMu18_v*",
     ],
     "ZmmHbbHighLumi" : [
         "HLT_IsoMu24_eta2p1_v*",
@@ -123,6 +135,10 @@ triggerTable = {
         "HLT_IsoTkMu20_v*",
         "HLT_Mu20_v*",
         "HLT_TkMu20_v*",
+        "HLT_IsoMu18_v*",
+        "HLT_OldIsoMu18_v*",
+        "HLT_IsoTkMu18_v*",
+        "HLT_OldIsoTkMu18_v*",
         "HLT_Mu40_eta2p1_PFJet200_PFJet50_v*",
         "HLT_IsoMu16_eta2p1_CaloMET30_v*",
         "HLT_Mu16_eta2p1_CaloMET30_v*",
@@ -176,18 +192,25 @@ triggerTable = {
     ],
 
     "HH4bAll" : [
-        "HLT_QuadJet45_TripleCSV0p5_v*",
-        "HLT_QuadJet45_DoubleCSV0p5_v*",
-        "HLT_DoubleJet90_Double30_TripleCSV0p5_v*",
-        "HLT_DoubleJet90_Double30_DoubleCSV0p5_v*",
+        "HLT_QuadJet45_TripleBTagCSV0p67_v*",
+        "HLT_QuadJet45_DoubleBTagCSV0p67_v*",
+        "HLT_DoubleJet90_Double30_TripleBTagCSV0p67_v*",
+        "HLT_DoubleJet90_Double30_DoubleBTagCSV0p67_v*",
     ],
     "HH4bHighLumi" : [
-        "HLT_QuadJet45_TripleCSV0p5_v*",
-        "HLT_DoubleJet90_Double30_TripleCSV0p5_v*",
+        "HLT_QuadJet45_TripleBTagCSV0p67_v*",
+        "HLT_DoubleJet90_Double30_TripleBTagCSV0p67_v*",
     ],
     "HH4bLowLumi" : [
-        "HLT_QuadJet45_TripleCSV0p5_v*",
-        "HLT_DoubleJet90_Double30_TripleCSV0p5_v*",
+        "HLT_QuadJet45_TripleBTagCSV0p67_v*",
+        "HLT_DoubleJet90_Double30_TripleBTagCSV0p67_v*",
+
+        "HLT_AK8DiPFJet250_200_TrimMass30_BTagCSV0p45_v*",
+        "HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV0p45_v*",
+        "HLT_AK8PFHT600_TrimR0p1PT0p03Mass50_BTagCSV0p45_v*",
+        "HLT_AK8PFHT650_TrimR0p1PT0p03Mass50_v*",
+        "HLT_AK8PFHT700_TrimR0p1PT0p03Mass50_v*",
+        "HLT_AK8PFJet360_TrimMass30_v*",
     ],
     "ttHleptonic" : [
         "HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*",
@@ -195,15 +218,15 @@ triggerTable = {
         "HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v*",
         "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*",
         "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v*",
-        "HLT_Ele27_WP85_Gsf_v*",
-        "HLT_IsoMu17_eta2p1_v*",
+        "HLT_Ele27_eta2p1_WPLoose_Gsf_v*",
+        "HLT_IsoMu18_v*",
     ],
     "ttHhardonicAll" : [
         "HLT_PFHT450_SixJet40_PFBTagCSV0p72_v*",
         "HLT_PFHT450_SixJet40_v*",
         "HLT_PFHT400_SixJet30_BTagCSV0p55_2PFBTagCSV0p72_v*",
         "HLT_PFHT400_SixJet30_v*",
-        "HLT_PFHT350_v*", 
+        "HLT_PFHT350_v*",
     ],
     "ttHhardonicHighLumi" : [
         "HLT_PFHT400_SixJet30_BTagCSV0p55_2PFBTagCSV0p72_v*",
@@ -215,8 +238,8 @@ triggerTable = {
     ],
 
     "hadronic" : [
-        "HLT_PFHT750_4Jet_v*",
-        "HLT_PFHT900_v*",
+        "HLT_PFHT750_4JetPt50_v*",
+        "HLT_PFHT800_v*",
         "HLT_PFJet40_v*",
         "HLT_PFJet60_v*",
         "HLT_PFJet80_v*",
@@ -226,5 +249,13 @@ triggerTable = {
         "HLT_PFJet320_v*",
         "HLT_PFJet400_v*",
         "HLT_PFJet450_v*",
+
+        "HLT_DiPFJetAve40_v*",
+        "HLT_DiPFJetAve60_v*",
+        "HLT_DiPFJetAve80_v*",
+        "HLT_DiPFJetAve140_v*",
+        "HLT_DiPFJetAve200_v*",
+        "HLT_DiPFJetAve260_v*",
+        "HLT_DiPFJetAve320_v*",
     ],
 }

--- a/VHbbAnalysis/Heppy/python/TriggerTableData.py
+++ b/VHbbAnalysis/Heppy/python/TriggerTableData.py
@@ -1,4 +1,8 @@
 triggerTable = {
+    "ZnnHbb" : [
+        "HLT_PFMET90_PFMHT90_IDTight_v*",
+        "HLT_PFMET170_NoiseCleaned_v*",
+    ],
     "ZnnHbbAll" : [
         "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDTight_BTagCSV0p72_v*",
         "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDTight_v*",
@@ -10,15 +14,6 @@ triggerTable = {
         "HLT_DiCentralPFJet55_PFMET110_NoiseCleaned_v*",
         "HLT_PFHT350_PFMET100_NoiseCleaned_v*",
     ],
-    "ZnnHbbHighLumi" : [
-        "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDTight_BTagCSV0p72_v*",
-        "HLT_PFMET120_PFMHT120_IDTight_v*",
-        "HLT_PFMET170_NoiseCleaned_v*",
-    ],
-    "ZnnHbbLowLumi" : [
-        "HLT_PFMET90_PFMHT90_IDTight_v*",
-    ],
-
     "ZeeHbbAll" : [
         "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*",
         "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v*",

--- a/VHbbAnalysis/Heppy/test/vhbb.py
+++ b/VHbbAnalysis/Heppy/test/vhbb.py
@@ -375,8 +375,9 @@ sequence = [jsonAna,LHEAna,LHEWeightAna,FlagsAna, hbheAna, GenAna,VHGenAna,PUAna
 from PhysicsTools.Heppy.utils.miniAodFiles import miniAodFiles
 sample = cfg.MCComponent(
 	files = [
+		"root://xrootd.ba.infn.it//store/mc/RunIIFall15DR76/ZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v12-v1/70000/3816EEA3-EAA7-E511-9114-02163E011747.root"
 #		"root://xrootd.ba.infn.it//store/mc/RunIIFall15MiniAODv1/TT_TuneCUETP8M1_13TeV-powheg-scaledown-pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/30000/045996FE-A19D-E511-B76D-D4AE526A0B47.root" ##ttbar
-		"045996FE-A19D-E511-B76D-D4AE526A0B47.root" ##ttbar
+		#"045996FE-A19D-E511-B76D-D4AE526A0B47.root" ##ttbar
 		#"root://xrootd.ba.infn.it//store/mc/RunIIFall15MiniAODv2/DYJetsToLL_M-100to200_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12_ext1-v1/60000/027D7153-29BF-E511-A2BC-0025B3E025B6.root"
 		],
     #files = ["226BB247-A565-E411-91CF-00266CFF0AF4.root"],

--- a/VHbbAnalysis/Heppy/test/vhbb_data.py
+++ b/VHbbAnalysis/Heppy/test/vhbb_data.py
@@ -10,10 +10,6 @@ sample.files=[
 sample.json="json.txt"
 
 
-TriggerObjectsAna.triggerObjectInputTag = ('selectedPatTrigger','','RECO')
-FlagsAna.processName='RECO'
-TrigAna.triggerBits = triggerTableData
-
 # and the following runs the process directly 
 if __name__ == '__main__':
     from PhysicsTools.HeppyCore.framework.looper import Looper 


### PR DESCRIPTION
New trigger table for 76X MC. Copied from the triggerTable data.
76X HLT configuration:
http://cmslxr.fnal.gov/source/HLTrigger/Configuration/python/HLT_25ns14e33_v4_cff.py?v=CMSSW_7_6_1