### PR TITLE
Tt h htt 2016 mar30

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
@@ -119,8 +119,10 @@ class LeptonAnalyzer( Analyzer ):
     
         #rho for muons
         self.handles['rhoMu'] = AutoHandle( self.cfg_ana.rhoMuon, 'double')
+        self.handles['rhoMu_miniIsolation'] = AutoHandle( self.cfg_ana.rhoMuon_miniIsolation, 'double')
         #rho for electrons
         self.handles['rhoEle'] = AutoHandle( self.cfg_ana.rhoElectron, 'double')
+        self.handles['rhoEle_miniIsolation'] = AutoHandle( self.cfg_ana.rhoElectron_miniIsolation, 'double')
 
         # JP/CV: add Spring15 EGamma POG electron ID MVA
         # ( https://twiki.cern.ch/twiki/bin/viewauth/CMS/MultivariateElectronIdentificationRun2#Recipes_for_7_4_12_Spring15_MVA )
@@ -266,6 +268,7 @@ class LeptonAnalyzer( Analyzer ):
         # Attach EAs for isolation:
         for mu in allmuons:
           mu.rho = float(self.handles['rhoMu'].product()[0])
+          mu.rho_miniIsolation = float(self.handles['rhoMu_miniIsolation'].product()[0])
           if self.muEffectiveArea == "Data2012":
               if   aeta < 1.0  : mu.EffectiveArea03 = 0.382;
               elif aeta < 1.47 : mu.EffectiveArea03 = 0.317;
@@ -345,6 +348,7 @@ class LeptonAnalyzer( Analyzer ):
         # fill EA for rho-corrected isolation
         for ele in allelectrons:
           ele.rho = float(self.handles['rhoEle'].product()[0])
+          ele.rho_miniIsolation = float(self.handles['rhoEle_miniIsolation'].product()[0])
           if self.eleEffectiveArea == "Data2012":
               # https://twiki.cern.ch/twiki/bin/viewauth/CMS/EgammaEARhoCorrection?rev=14
               SCEta = abs(ele.superCluster().eta())
@@ -485,7 +489,7 @@ class LeptonAnalyzer( Analyzer ):
                 #mu.miniAbsIsoNHadSV = self.IsolationComputer.neutralHadAbsIsoRaw(mu.physObj, mu.miniIsoR, 0.0, 0.0) 
                 #mu.miniAbsIsoNeutral = mu.miniAbsIsoPhoSV + mu.miniAbsIsoNHadSV  
             if puCorr == "rhoArea":
-                mu.miniAbsIsoNeutral = max(0.0, mu.miniAbsIsoNeutral - mu.rho * mu.EffectiveArea03 * (mu.miniIsoR/0.3)**2)
+                mu.miniAbsIsoNeutral = max(0.0, mu.miniAbsIsoNeutral - mu.rho_miniIsolation * mu.EffectiveArea03 * (mu.miniIsoR/0.3)**2)
             elif puCorr == "deltaBeta":
                 if what == "mu":
                     mu.miniAbsIsoPU = self.IsolationComputer.puAbsIso(mu.physObj, mu.miniIsoR, 0.01, 0.5);
@@ -644,6 +648,8 @@ setattr(LeptonAnalyzer,"defaultConfig",cfg.Analyzer(
     electrons='slimmedElectrons',
     rhoMuon= 'fixedGridRhoFastjetAll',
     rhoElectron = 'fixedGridRhoFastjetAll',
+    rhoMuon_miniIsolation = 'fixedGridRhoFastjetCentralNeutral',
+    rhoElectron_miniIsolation = 'fixedGridRhoFastjetCentralNeutral',
 ##    photons='slimmedPhotons',
     # energy scale corrections and ghost muon suppression (off by default)
     doMuonScaleCorrections=False, 

--- a/VHbbAnalysis/Heppy/test/vhbb.py
+++ b/VHbbAnalysis/Heppy/test/vhbb.py
@@ -192,12 +192,13 @@ LepAna.doElectronScaleCorrections = {
 	}
 LepAna.mu_isoCorr  = "deltaBeta"
 #LepAna.loose_muon_isoCut = lambda muon : muon.relIso04 < 0.25 
-LepAna.loose_muon_isoCut = lambda muon : muon.relIso04 < 0.4
-LepAna.loose_muon_pt = 10.
+LepAna.loose_muon_isoCut = lambda muon : (muon.relIso04 < 0.4 or muon.miniRelIso < 0.4)
+LepAna.loose_muon_pt = 5.
 LepAna.ele_isoCorr = "rhoArea"
-LepAna.loose_electron_isoCut = lambda electron : electron.relIso03 < 0.4 
+LepAna.loose_electron_isoCut = lambda electron : (electron.relIso03 < 0.4 or electron.miniRelIso < 0.4)
 #LepAna.loose_electron_isoCut = lambda electron : ele_mvaEleID_Trig_preselection(electron)
-LepAna.loose_electron_pt = 10.
+LepAna.loose_electron_pt = 7.
+LepAna.loose_electron_eta = 2.5
 #LepAna.loose_electron_id = "mvaEleID-Spring15-25ns-Trig-V1-wp90"
 LepAna.doMiniIsolation = True
 


### PR DESCRIPTION
- allow to use different rho for mini-isolation
- relaxed pT cuts for electrons and muons
- relaxed isolation cut for electrons and muons to "standard" isolation < 0.4_pT or mini-isolation < 0.4_pT
