### PR TITLE
ttH-Htt 29.06.16

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
@@ -123,8 +123,10 @@ class LeptonAnalyzer( Analyzer ):
     
         #rho for muons
         self.handles['rhoMu'] = AutoHandle( self.cfg_ana.rhoMuon, 'double')
+        self.handles['rhoMu_miniIsolation'] = AutoHandle( self.cfg_ana.rhoMuon_miniIsolation, 'double')
         #rho for electrons
         self.handles['rhoEle'] = AutoHandle( self.cfg_ana.rhoElectron, 'double')
+        self.handles['rhoEle_miniIsolation'] = AutoHandle( self.cfg_ana.rhoElectron_miniIsolation, 'double')
 
         # JP/CV: add Spring15 EGamma POG electron ID MVA
         # ( https://twiki.cern.ch/twiki/bin/viewauth/CMS/MultivariateElectronIdentificationRun2#Recipes_for_7_4_12_Spring15_MVA )
@@ -276,6 +278,7 @@ class LeptonAnalyzer( Analyzer ):
         # Attach EAs for isolation:
         for mu in allmuons:
           mu.rho = float(self.handles['rhoMu'].product()[0])
+          mu.rho_miniIsolation = float(self.handles['rhoMu_miniIsolation'].product()[0])
           if self.muEffectiveArea == "Data2012":
               if   aeta < 1.0  : mu.EffectiveArea03 = 0.382;
               elif aeta < 1.47 : mu.EffectiveArea03 = 0.317;
@@ -356,6 +359,7 @@ class LeptonAnalyzer( Analyzer ):
         # fill EA for rho-corrected isolation
         for ele in allelectrons:
           ele.rho = float(self.handles['rhoEle'].product()[0])
+          ele.rho_miniIsolation = float(self.handles['rhoEle_miniIsolation'].product()[0])
           if self.eleEffectiveArea == "Data2012":
               # https://twiki.cern.ch/twiki/bin/viewauth/CMS/EgammaEARhoCorrection?rev=14
               SCEta = abs(ele.superCluster().eta())
@@ -505,7 +509,7 @@ class LeptonAnalyzer( Analyzer ):
                 #mu.miniAbsIsoNHadSV = self.IsolationComputer.neutralHadAbsIsoRaw(mu.physObj, mu.miniIsoR, 0.0, 0.0) 
                 #mu.miniAbsIsoNeutral = mu.miniAbsIsoPhoSV + mu.miniAbsIsoNHadSV  
             if puCorr == "rhoArea":
-                mu.miniAbsIsoNeutral = max(0.0, mu.miniAbsIsoNeutral - mu.rho * mu.EffectiveArea03 * (mu.miniIsoR/0.3)**2)
+                mu.miniAbsIsoNeutral = max(0.0, mu.miniAbsIsoNeutral - mu.rho_miniIsolation * mu.EffectiveArea03 * (mu.miniIsoR/0.3)**2)
             elif puCorr == "deltaBeta":
                 if what == "mu":
                     mu.miniAbsIsoPU = self.IsolationComputer.puAbsIso(mu.physObj, mu.miniIsoR, 0.01, 0.5);
@@ -711,6 +715,8 @@ setattr(LeptonAnalyzer,"defaultConfig",cfg.Analyzer(
     electrons='slimmedElectrons',
     rhoMuon= 'fixedGridRhoFastjetAll',
     rhoElectron = 'fixedGridRhoFastjetAll',
+    rhoMuon_miniIsolation = 'fixedGridRhoFastjetCentralNeutral',
+    rhoElectron_miniIsolation = 'fixedGridRhoFastjetCentralNeutral',
 ##    photons='slimmedPhotons',
     # energy scale corrections and ghost muon suppression (off by default)
     doMuonScaleCorrections=False, 

--- a/VHbbAnalysis/Heppy/python/VHbbAnalyzer.py
+++ b/VHbbAnalysis/Heppy/python/VHbbAnalyzer.py
@@ -486,10 +486,6 @@ class VHbbAnalyzer( Analyzer ):
 	ssThreshold = 200.
 	# filter events with less than 2 jets with pt 20
         event.jetsForHiggs = [x for x in event.cleanJets if self.cfg_ana.higgsJetsPreSelection(x) ]
-	if not  ( len(event.jetsForHiggs) >= 2  or (len(event.cleanJets) == 1 and event.cleanJets[0].pt() > ssThreshold ) ) :
-		return self.cfg_ana.passall
-        if event.Vtype < 0 and not ( sum(x.pt() > 30 for x in event.jetsForHiggs) >= 4 or sum(x.pt() for x in event.jetsForHiggs[:4]) > 160 ):
-                return self.cfg_ana.passall
 
         map(lambda x :x.qgl(),event.jetsForHiggs[:6])
         map(lambda x :x.qgl(),(x for x in event.jetsForHiggs if x.pt() > 30) )
@@ -548,6 +544,12 @@ class VHbbAnalyzer( Analyzer ):
        # Boost(hhh,-Hbalance2.BoostVector())
        # print "unboosted pt",hhh.Pt()
 #	self.makeJets(event,-Hbalance2.BoostVector())
+
+	if not  ( len(event.jetsForHiggs) >= 2  or (len(event.cleanJets) == 1 and event.cleanJets[0].pt() > ssThreshold ) ) :
+		return self.cfg_ana.passall
+        if event.Vtype < 0 and not ( sum(x.pt() > 30 for x in event.jetsForHiggs) >= 4 or sum(x.pt() for x in event.jetsForHiggs[:4]) > 160 ):
+                return self.cfg_ana.passall
+
         return True
 
 

--- a/VHbbAnalysis/Heppy/python/vhbbobj.py
+++ b/VHbbAnalysis/Heppy/python/vhbbobj.py
@@ -6,7 +6,7 @@ import ROOT
 from PhysicsTools.Heppy.analyzers.objects.autophobj import *
 from PhysicsTools.HeppyCore.utils.deltar import deltaPhi, deltaR
 from VHbbAnalysis.Heppy.signedSip import qualityTrk
-from VHbbAnalysis.Heppy.leptonMVA import ptRelv2
+from VHbbAnalysis.Heppy.leptonMVA import ptRelv2, jetLepAwareJEC
 
 import copy, os
 
@@ -49,7 +49,7 @@ leptonTypeVHbb = NTupleObjectType("leptonTypeVHbb", baseObjectTypes = [ leptonTy
     # TTH-id related variables
     NTupleVariable("mvaTTH",     lambda lepton : lepton.mvaValueTTH if hasattr(lepton,'mvaValueTTH') else -1, help="Lepton MVA (ttH version)"),
     NTupleVariable("jetOverlapIdx", lambda lepton : getattr(lepton, "jetOverlapIdx", -1), int, help="index of jet with overlapping PF constituents. If idx>=1000, then idx = idx-1000 and refers to discarded jets."),
-    NTupleVariable("jetPtRatio", lambda lepton : lepton.pt()/lepton.jet.pt() if hasattr(lepton,'jet') else -1, help="pt(lepton)/pt(nearest jet)"),
+    NTupleVariable("jetPtRatio", lambda lepton : lepton.pt()/jetLepAwareJEC(lepton).Pt() if hasattr(lepton,'jet') else -1, help="pt(lepton)/pt(nearest jet)"),
     NTupleVariable("jetBTagCSV", lambda lepton : lepton.jet.btag('pfCombinedInclusiveSecondaryVertexV2BJetTags') if hasattr(lepton,'jet') and hasattr(lepton.jet, 'btag') else -99, help="btag of nearest jet"),
     NTupleVariable("jetDR",      lambda lepton : deltaR(lepton.eta(),lepton.phi(),lepton.jet.eta(),lepton.jet.phi()) if hasattr(lepton,'jet') else -1, help="deltaR(lepton, nearest jet)"),
     NTupleVariable("mvaTTHjetPtRatio", lambda lepton : lepton.pt()/lepton.jet_leptonMVA.pt() if hasattr(lepton,'jet_leptonMVA') else -1, help="pt(lepton)/pt(nearest jet with pT > 25 GeV)"),

--- a/VHbbAnalysis/Heppy/test/vhbb.py
+++ b/VHbbAnalysis/Heppy/test/vhbb.py
@@ -192,12 +192,13 @@ LepAna = LeptonAnalyzer.defaultConfig
 #	}
 LepAna.mu_isoCorr  = "deltaBeta"
 #LepAna.loose_muon_isoCut = lambda muon : muon.relIso04 < 0.25 
-LepAna.loose_muon_isoCut = lambda muon : muon.relIso04 < 0.4
-LepAna.loose_muon_pt = 10.
+LepAna.loose_muon_isoCut = lambda muon : (muon.relIso04 < 0.4 or muon.miniRelIso < 0.4)
+LepAna.loose_muon_pt = 4.5
 LepAna.ele_isoCorr = "rhoArea"
-LepAna.loose_electron_isoCut = lambda electron : electron.relIso03 < 0.4 
+LepAna.loose_electron_isoCut = lambda electron : (electron.relIso03 < 0.4 or electron.miniRelIso < 0.4)
 #LepAna.loose_electron_isoCut = lambda electron : ele_mvaEleID_Trig_preselection(electron)
-LepAna.loose_electron_pt = 10.
+LepAna.loose_electron_pt = 6.5
+LepAna.loose_electron_eta = 2.5
 #LepAna.loose_electron_id = "mvaEleID-Spring15-25ns-Trig-V1-wp90"
 LepAna.doMiniIsolation = True
 


### PR DESCRIPTION
- relax lepton pT cuts
  - muons 10 -> 4.5; electrons 10 -> 6.5
  - tested: the number of gen level b-jets vetoed by leptons of lower pT increased by ~1%
- set electron abs eta cut to 2.5 (default 2.4)
- allow to use different rho for mini-isolation
- include mini-isolation in the isolation cuts as well

edit/update:
- use jet pT value after JEC in jetPtRatio (lepton pT / nearest jet pT)
- move a few lines to the end of process() in VhbbAnalyzer so that the values for Ntuple branches are always calculated
