### PR TITLE
Reshuffle of the fully hadronic TTH triggers

### DIFF
--- a/VHbbAnalysis/Heppy/python/TriggerTable.py
+++ b/VHbbAnalysis/Heppy/python/TriggerTable.py
@@ -223,13 +223,6 @@ triggerTable = {
         "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*",
         "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v*",
     ],
-    "ttHhardonicAll" : [
-        "HLT_PFHT450_SixJet40_BTagCSV_p056_v*",
-        "HLT_PFHT450_SixJet40_v*",
-        "HLT_PFHT400_SixJet30_DoubleBTagCSV_p056_v*",
-        "HLT_PFHT400_SixJet30_v*",
-        "HLT_PFHT350_v*",
-    ],
     "ttH_FH" : [
         "HLT_PFHT450_SixJet40_BTagCSV_p056_v*",
         "HLT_PFHT400_SixJet30_DoubleBTagCSV_p056_v*",

--- a/VHbbAnalysis/Heppy/python/TriggerTable.py
+++ b/VHbbAnalysis/Heppy/python/TriggerTable.py
@@ -230,15 +230,14 @@ triggerTable = {
         "HLT_PFHT400_SixJet30_v*",
         "HLT_PFHT350_v*",
     ],
-    "ttHhardonicHighLumi" : [
-        "HLT_PFHT400_SixJet30_DoubleBTagCSV_p056_v*",
+    "ttH_FH" : [
         "HLT_PFHT450_SixJet40_BTagCSV_p056_v*",
-    ],
-    "ttHhardonicLowLumi" : [
         "HLT_PFHT400_SixJet30_DoubleBTagCSV_p056_v*",
-        "HLT_PFHT450_SixJet40_BTagCSV_p056_v*",
     ],
-
+    "ttH_FH_prescaled" : [
+        "HLT_PFHT450_SixJet40_v*",
+        "HLT_PFHT400_SixJet30_v*",
+    ],
     "hadronic" : [
         "HLT_PFHT750_4JetPt50_v*",
         "HLT_PFHT800_v*",

--- a/VHbbAnalysis/Heppy/python/TriggerTableData.py
+++ b/VHbbAnalysis/Heppy/python/TriggerTableData.py
@@ -223,22 +223,14 @@ triggerTable = {
         "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*",
         "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v*",
     ],
-    "ttHhardonicAll" : [
+    "ttH_FH" : [
         "HLT_PFHT450_SixJet40_BTagCSV_p056_v*",
+        "HLT_PFHT400_SixJet30_DoubleBTagCSV_p056_v*",
+    ],
+    "ttH_FH_prescaled" : [
         "HLT_PFHT450_SixJet40_v*",
-        "HLT_PFHT400_SixJet30_DoubleBTagCSV_p056_v*",
         "HLT_PFHT400_SixJet30_v*",
-        "HLT_PFHT350_v*",
     ],
-    "ttHhardonicHighLumi" : [
-        "HLT_PFHT400_SixJet30_DoubleBTagCSV_p056_v*",
-        "HLT_PFHT450_SixJet40_BTagCSV_p056_v*",
-    ],
-    "ttHhardonicLowLumi" : [
-        "HLT_PFHT400_SixJet30_DoubleBTagCSV_p056_v*",
-        "HLT_PFHT450_SixJet40_BTagCSV_p056_v*",
-    ],
-
     "hadronic" : [
         "HLT_PFHT750_4JetPt50_v*",
         "HLT_PFHT800_v*",


### PR DESCRIPTION
This PR changes the TTH FH trigger grouping in order to have them similar to the leptonic TTH trigger groups.
