### PR TITLE
do not attempt calib for zeropt subjets

### DIFF
--- a/VHbbAnalysis/Heppy/python/AdditionalBoost.py
+++ b/VHbbAnalysis/Heppy/python/AdditionalBoost.py
@@ -1028,8 +1028,10 @@ class AdditionalBoost( Analyzer ):
 
 
                 sj_w1_cal = Jet(sj_w1_uncal).__copy__() 
-                self.jetReCalibratorAK4.correct(sj_w1_cal, rho, addCorr=True,addShifts=True, recalcMet = False)
+                if sj_w1_cal.pt()>0:
+                    self.jetReCalibratorAK4.correct(sj_w1_cal, rho, addCorr=True,addShifts=True, recalcMet = False)
 
+                #print sj_w2.pt(), sj_w2.eta()
 
                 # Calibrate the subjets: W2
                 sj_w2_uncal = Jet(sj_w2)        
@@ -1038,7 +1040,8 @@ class AdditionalBoost( Analyzer ):
                 sj_w2_uncal._rawFactorMultiplier =1.
 
                 sj_w2_cal = Jet(sj_w2_uncal).__copy__() 
-                self.jetReCalibratorAK4.correct(sj_w2_cal, rho, addCorr=True,addShifts=True, recalcMet = False)
+                if sj_w2_cal.pt()>0:
+                    self.jetReCalibratorAK4.correct(sj_w2_cal, rho, addCorr=True,addShifts=True, recalcMet = False)
 
                 # Calibrate the subjets: NonW
                 sj_nonw_uncal = Jet(sj_nonw)        
@@ -1047,7 +1050,8 @@ class AdditionalBoost( Analyzer ):
                 sj_nonw_uncal._rawFactorMultiplier =1.
 
                 sj_nonw_cal = Jet(sj_nonw_uncal).__copy__() 
-                self.jetReCalibratorAK4.correct(sj_nonw_cal, rho, addCorr=True,addShifts=True, recalcMet = False)
+                if sj_nonw_cal.pt()>0:
+                    self.jetReCalibratorAK4.correct(sj_nonw_cal, rho, addCorr=True,addShifts=True, recalcMet = False)
 
                 # Do all subjets pass the JetID requirements
                 event.httCandidates[i].subjetIDPassed = all([passesJetId(x) for x in [sj_w1_cal, sj_w2_cal, sj_nonw_cal]])

--- a/VHbbAnalysis/Heppy/python/vhbbobj.py
+++ b/VHbbAnalysis/Heppy/python/vhbbobj.py
@@ -483,7 +483,7 @@ httType = NTupleObjectType("htt",  baseObjectTypes = [ fourVectorType ], variabl
     NTupleVariable("sjW1masscal", lambda x : x.sjW1masscal, help = "Leading W Subjet mass (calibrated)"),
     NTupleVariable("sjW1mass", lambda x : x.sjW1mass, help = "Leading W Subjet mass"),
     NTupleVariable("sjW1btag", lambda x : x.sjW1btag, help = "Leading W Subjet btag"),
-    NTupleVariable("sjW1corr", lambda x : x.sjW1.corr),
+    NTupleVariable("sjW1corr", lambda x : x.sjW1.corr if hasattr(x, "corr") else -1. ),
     # Second W Subjet (pt)
     NTupleVariable("sjW2ptcal", lambda x : x.sjW2ptcal,help = "Second Subjet pT (calibrated)"),
     NTupleVariable("sjW2pt",   lambda x : x.sjW2pt,   help = "Second Subjet pT"),
@@ -492,7 +492,7 @@ httType = NTupleObjectType("htt",  baseObjectTypes = [ fourVectorType ], variabl
     NTupleVariable("sjW2masscal", lambda x : x.sjW2masscal, help = "Second Subjet mass (calibrated)"),
     NTupleVariable("sjW2mass", lambda x : x.sjW2mass, help = "Second Subjet mass"),
     NTupleVariable("sjW2btag", lambda x : x.sjW2btag, help = "Second Subjet btag"),
-    NTupleVariable("sjW2corr", lambda x : x.sjW2.corr),
+    NTupleVariable("sjW2corr", lambda x : x.sjW2.corr if hasattr(x, "corr") else -1.),
     # Non-W Subjet
     NTupleVariable("sjNonWptcal",lambda x : x.sjNonWptcal,help = "Non-W Subjet pT (calibrated)"),
     NTupleVariable("sjNonWpt",   lambda x : x.sjNonWpt,   help = "Non-W Subjet pT"),
@@ -501,7 +501,7 @@ httType = NTupleObjectType("htt",  baseObjectTypes = [ fourVectorType ], variabl
     NTupleVariable("sjNonWmasscal", lambda x : x.sjNonWmasscal, help = "Non-W Subjet mass (calibrated)"),
     NTupleVariable("sjNonWmass", lambda x : x.sjNonWmass, help = "Non-W Subjet mass"),
     NTupleVariable("sjNonWbtag", lambda x : x.sjNonWbtag, help = "Non-W Subjet btag"),
-    NTupleVariable("sjNonWcorr", lambda x : x.sjNonW.corr),
+    NTupleVariable("sjNonWcorr", lambda x : x.sjNonW.corr if hasattr(x, "corr") else -1.),
     ])
    
 


### PR DESCRIPTION
division by zero was due to zero pt HTT subjets. We only want to cut on calibrated ones (at around 30 GeV) so we just don't call calibration if pT is zero now