### PR TITLE
Fix JEC issue for Boost and update GT

### DIFF
--- a/VHbbAnalysis/Heppy/python/AdditionalBoost.py
+++ b/VHbbAnalysis/Heppy/python/AdditionalBoost.py
@@ -659,7 +659,8 @@ class AdditionalBoost( Analyzer ):
         GT        = cfg_ana.GT if hasattr(cfg_ana,'GT')   else "Summer15_25nsV6_DATA"
         jecPath   = cfg_ana.jecPath if hasattr(cfg_ana,'jecPath') else "."
         isMC      = cfg_ana.isMC if hasattr(cfg_ana,'isMC') else False
-
+        facJEC    = cfg_ana.facJEC if hasattr(cfg_ana,'facJEC') else ["Total"]
+        
         self.skip_ca15 = skip_ca15
 
         # Prepare re-calibrator
@@ -694,38 +695,7 @@ class AdditionalBoost( Analyzer ):
                                                   doResidual, 
                                                   jecPath,
                                                   skipLevel1=False,
-                                                  factorizedJetCorrections  = ["AbsoluteFlavMap",
-                                                                               "AbsoluteMPFBias",
-                                                                               "AbsoluteScale",
-                                                                               "AbsoluteStat",
-                                                                               "FlavorQCD",
-                                                                               "Fragmentation",
-                                                                               "PileUpDataMC",
-                                                                               "PileUpEnvelope",
-                                                                               "PileUpMuZero",
-                                                                               "PileUpPtBB",
-                                                                               "PileUpPtEC1",
-                                                                               "PileUpPtEC2",
-                                                                               "PileUpPtHF",
-                                                                               "PileUpPtRef",
-                                                                               "RelativeFSR",
-                                                                               "RelativeStatFSR",
-                                                                               "RelativeJEREC1",
-                                                                               "RelativeJEREC2",
-                                                                               "RelativeJERHF",
-                                                                               "RelativePtBB",
-                                                                               "RelativePtEC1",
-                                                                               "RelativePtEC2",
-                                                                               "RelativePtHF",
-                                                                               "RelativeStatEC",
-                                                                               #"RelativeStatEC2", #Does not exist in Spring16
-                                                                               "RelativeStatHF",
-                                                                               "SinglePionECAL",
-                                                                               "SinglePionHCAL",
-                                                                               "TimeEta",
-                                                                               "TimePt",
-                                                                               "Total"
-                                                                           ])
+                                                  factorizedJetCorrections  = facJEC)
 
 
 

--- a/VHbbAnalysis/Heppy/test/vhbb_combined.py
+++ b/VHbbAnalysis/Heppy/test/vhbb_combined.py
@@ -18,10 +18,11 @@ boostana=cfg.Analyzer(
 )
 
 #boostana.GT = "Fall15_25nsV2_DATA" 
-boostana.GT = "Spring16_25nsV6_DATA" # we do L2L3 for MC and L2L3Res for data. Can therefor use data GT for both
+boostana.GT = "Spring16_23Sep2016GV2_DATA" # we do L2L3 for MC and L2L3Res for data. Can therefor use data GT for both
 boostana.jecPath = os.environ['CMSSW_BASE']+"/src/VHbbAnalysis/Heppy/data/jec"
 boostana.isMC = sample.isMC
 boostana.skip_ca15 = False
+boostana.facJEC = factorizedJetCorrections
 sequence.insert(sequence.index(VHbb),boostana)
 
 #used freshly computed MVA ID variables
@@ -156,7 +157,7 @@ preprocessor = CmsswPreprocessor("combined_cmssw.py", options = {"isMC":sample.i
 config.preprocessor=preprocessor
 if __name__ == '__main__':
     from PhysicsTools.HeppyCore.framework.looper import Looper 
-    looper = Looper( 'Loop', config, nPrint = 0, nEvents = 20)
+    looper = Looper( 'Loop', config, nPrint = 0, nEvents = 100)
     import time
     import cProfile
     p = cProfile.Profile(time.clock)


### PR DESCRIPTION
We had a second copy of the factorized JEC components in AdditionalBoost, so it tried to access some components that were not in the new GT.

Made it so that now AdditionalBoost gets the list from vhbb, so all the info is in one place.

Also updated the boosted global tag to the latest.