### PR TITLE
Fixes for heppy

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/core/AutoFillTreeProducer.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/AutoFillTreeProducer.py
@@ -214,7 +214,6 @@ class AutoFillTreeProducer( TreeAnalyzerNumpy ):
         
         for v in self.globalVariables:
             if v.mcOnly and not isMC:
-                print "skipping", coll
                 continue
             anclass += "        event.{0} = getattr(event.input, \"{0}\", None)\n".format(v.name) 
         

--- a/PhysicsTools/Heppy/python/analyzers/core/AutoFillTreeProducer.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/AutoFillTreeProducer.py
@@ -213,7 +213,6 @@ class AutoFillTreeProducer( TreeAnalyzerNumpy ):
             anclass += "        event.{0} = {0}.make_obj(event.input)\n".format(coll.name)
         
         for v in self.globalVariables:
-            print v, v.mcOnly
             if v.mcOnly and not isMC:
                 print "skipping", coll
                 continue

--- a/PhysicsTools/Heppy/python/analyzers/core/AutoFillTreeProducer.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/AutoFillTreeProducer.py
@@ -213,7 +213,9 @@ class AutoFillTreeProducer( TreeAnalyzerNumpy ):
             anclass += "        event.{0} = {0}.make_obj(event.input)\n".format(coll.name)
         
         for v in self.globalVariables:
-            if coll.mcOnly and not isMC:
+            print v, v.mcOnly
+            if v.mcOnly and not isMC:
+                print "skipping", coll
                 continue
             anclass += "        event.{0} = getattr(event.input, \"{0}\", None)\n".format(v.name) 
         

--- a/PhysicsTools/HeppyCore/python/framework/config.py
+++ b/PhysicsTools/HeppyCore/python/framework/config.py
@@ -303,8 +303,8 @@ class Component( CFG ):
 
 class DataComponent( Component ):
 
-    def __init__(self, name, files, intLumi=None, triggers=[], json=None):
-        super(DataComponent, self).__init__(name, files, triggers=triggers)
+    def __init__(self, name, files, intLumi=None, triggers=[], json=None, **kwargs):
+        super(DataComponent, self).__init__(name, files, triggers=triggers, **kwargs)
         self.isData = True
         self.intLumi = intLumi
         self.json = json


### PR DESCRIPTION
Needed to fix `DataComponent` in heppy (`**kwargs` was not properly propagated, causing `tree_name` not to be usable), so that it works the same as `MCComponent`.
Also, fixed a small bug in the wrapper-generation functionality of `AutoFillTreeProducer`.

Both fixes are needed for the ttH analysis to run on data.

@arizzi @cbernet I want to also push these upstream to cbernet/heppy, please let me know how and into which branch you prefer me to do it.